### PR TITLE
Add custom stringifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Total Tabs Associated: **3** | Opened Tabs: **2** | Closed Tabs: **1**
 var config = {
   onHandshakeCallback: function () { ... },
   onPollingCallback: function () { ... },
-  onChildCommunication: function () { .. }
+  onChildCommunication: function () { ... }
 }
 var parent = new AcrossTabs.Parent(config);
 ```
@@ -140,16 +140,20 @@ var parent = new AcrossTabs.Parent(config);
 * `onChildCommunication`: Callback to be called when child sends message
 * `onPollingCallback`: Callback to be called every time a tab is polled for its status
 * `origin`: whitelist `origin` for securing `postMessage` communication. It will discard the malicious messages trying to trick the behavior. Eg. http://example.com
+* `parse`: parser used when parsing messages, defaults to `JSON.parse`
+* `stringify`: stringifier used when converting data into messages, defaults to `JSON.stringify`
 
-| Config Keys                |     default    |      accepts                              |
-| ---------------------     | -------------- | ----------------------------------------- |
-| **heartBeatInterval**     |     500 msec   |  A number representing milliseconds       |
-| **removeClosedTabs**      |     false      |            Boolean                        |
-| **shouldInitImmediately** |     true       |            Boolean                        |
-| **onHandshakeCallback**   |     Undefined   |        Function as callback               |
-| **onChildCommunication**  |     Undefined   |        Function as callback               |
-| **onPollingCallback**     |     Undefined   |        Function as callback               |
-| **origin**                |     '*'        |            String(url)                    |
+| Config Keys               | default        | accepts                            |
+| ------------------------- | -------------- | ---------------------------------- |
+| **heartBeatInterval**     | 500 msec       | A number representing milliseconds |
+| **removeClosedTabs**      | false          | Boolean                            |
+| **shouldInitImmediately** | true           | Boolean                            |
+| **onHandshakeCallback**   | Undefined      | Function as callback               |
+| **onChildCommunication**  | Undefined      | Function as callback               |
+| **onPollingCallback**     | Undefined      | Function as callback               |
+| **origin**                | '*'            | String(url)                        |
+| **parse**                 | JSON.parse     | Function                           |
+| **stringify**             | JSON.stringify | Function                           |
 
 
 **New(Child tab)**
@@ -175,16 +179,20 @@ var child =  new AcrossTabs.Child(config);
 * `onParentCommunication`: Callback to be invoked whenever Parent communicates with the child tab
 * `isSiteInsideFrame`: If the library is loaded inside an iframe in the child tab, this needs to be set `true` for maintaining proper window/frame(s) references
 * `origin`: whitelist `origin` for securing `postMessage` communication. It will discard the malicious messages trying to trick the behavior. Eg. http://example.com
+* `parse`: parser used when parsing messages, defaults to `JSON.parse`
+* `stringify`: stringifier used when converting data into messages, defaults to `JSON.stringify`
 
-| Config Keys                |     default    |      accepts                              |
-| ------------------------- | -------------- | ----------------------------------------- |
-| **handshakeExpiryLimit**  |    5000 msec   |    A number representing milliseconds     |
-| **isSiteInsideFrame**     |      null      |    If child tab has actual site in a fram |
-| **onReady**               |    Undefined    |        Function as callback               |
-| **onInitialize**          |    Undefined    |        Function as callback               |
-| **onParentDisconnect**    |    Undefined    |        Function as callback               |
-| **onParentCommunication** |    Undefined    |        Function as callback               |
-| **origin**                |     '*'        |            String(url)                    |
+| Config Keys               | default        | accepts                                |
+| ------------------------- | -------------- | -------------------------------------- |
+| **handshakeExpiryLimit**  | 5000 msec      | A number representing milliseconds     |
+| **isSiteInsideFrame**     | null           | If child tab has actual site in a fram |
+| **onReady**               | Undefined      | Function as callback                   |
+| **onInitialize**          | Undefined      | Function as callback                   |
+| **onParentDisconnect**    | Undefined      | Function as callback                   |
+| **onParentCommunication** | Undefined      | Function as callback                   |
+| **origin**                | '*'            | String(url)                            |
+| **parse**                 | JSON.parse     | Function                               |
+| **stringify**             | JSON.stringify | Function                               |
 
 **Example** is included in the `example` folder. `Vanilla JS` and `Vue js` versions are there to test out.
 *Note:* Run `npm install` if you wish to run `vuejs` example since the example needs the `vue-js` library to work.
@@ -200,9 +208,9 @@ Refer [above section](#create-an-instance--reference-before-using) on how to cre
   Saves `data` in specific `key` in sessionStorage. If the key is not provided, the library will warn.
   Following types of JavaScript objects are supported:
 
-  |   Parameter   |        Description                                   |
-  | ------------- | ---------------------------------------------------- |
-  |     config     |     For opening a new tab i.e. URL and windowName    |
+  | Parameter | Description                                   |
+  | --------- | --------------------------------------------- |
+  | config    | For opening a new tab i.e. URL and windowName |
 
   ```
     parent.openNewTab({url: 'http://example.com', windowName: 'AcrossTab'});
@@ -253,9 +261,9 @@ Refer [above section](#create-an-instance--reference-before-using) on how to cre
 
   Closes a particular tab whose id is provided.
 
-  |   Parameter   |        Description                |
-  | ------------- | --------------------------------- |
-  |     id        |     id of the tab to be closed    |
+  | Parameter | Description                |
+  | --------- | -------------------------- |
+  | id        | id of the tab to be closed |
 
   ```
     parent.closeTab('57cd47da-d98e-4a2d-814c-9b07cb51059c');
@@ -265,9 +273,9 @@ Refer [above section](#create-an-instance--reference-before-using) on how to cre
 
   Sends a same `message` to all the opened tabs.
 
-  |   Parameter   |        Description          |
-  | ------------- | --------------------------- |
-  |     msg       |        msg to be ent        |
+  | Parameter | Description   |
+  | --------- | ------------- |
+  | msg       | msg to be ent |
 
   ```
     parent.broadCastAll('Hello my dear Child! A greeting from Parent.');
@@ -277,10 +285,10 @@ Refer [above section](#create-an-instance--reference-before-using) on how to cre
 
   Sends a `message` to a particular opened tab.
 
-  |   Parameter   |        Description            |
-  | ------------- | ----------------------------- |
-  |     id        |  id of the tab to send an msg |
-  |     msg       |        msg to be sent         |
+  | Parameter | Description                  |
+  | --------- | ---------------------------- |
+  | id        | id of the tab to send an msg |
+  | msg       | msg to be sent               |
 
   ```
     parent.broadCastTo('57cd47da-d98e-4a2d-814c-9b07cb51059c', 'Hey! Can you run the script: worker.js? Thanks!');
@@ -300,9 +308,9 @@ Refer [above section](#create-an-instance--reference-before-using) on how to cre
 
   Sends a `message` to the `Parent` tab.
 
-  |   Parameter   |        Description            |
-  | ------------- | ----------------------------- |
-  |     msg       |       msg to be sent          |
+  | Parameter | Description    |
+  | --------- | -------------- |
+  | msg       | msg to be sent |
 
   ```
     child.sendMessageToParent('Hey Parent! I\'m done with my work.');

--- a/src/child.js
+++ b/src/child.js
@@ -20,10 +20,10 @@ class Child {
     if (typeof config.shouldInitImmediately === 'undefined') {
       config.shouldInitImmediately = true;
     }
-    if (typeof config.parse === 'undefined') {
+    if (typeof config.parse !== 'function') {
       config.parse = JSON.parse;
     }
-    if (typeof config.stringify === 'undefined') {
+    if (typeof config.stringify !== 'function') {
       config.stringify = JSON.stringify;
     }
 

--- a/src/child.js
+++ b/src/child.js
@@ -100,7 +100,7 @@ class Child {
 
     // Expecting JSON data
     try {
-      actualData = this.parse(dataReceived);
+      actualData = this.config.parse(dataReceived);
       this.tabId = actualData && actualData.id;
       this.tabName = actualData && actualData.name;
       this.tabParentName = actualData && actualData.parentName;
@@ -174,7 +174,7 @@ class Child {
       dataReceived = data.split(PostMessageEventNamesEnum.PARENT_COMMUNICATED)[1];
 
       try {
-        dataReceived = this.parse(dataReceived);
+        dataReceived = this.config.parse(dataReceived);
       } catch (e) {
         throw new Error(WarningTextEnum.INVALID_JSON);
       }
@@ -226,7 +226,7 @@ class Child {
 
     let type = _prefixType || PostMessageEventNamesEnum.CUSTOM;
 
-    msg = type + this.stringify(msg);
+    msg = type + this.config.stringify(msg);
 
     if (window.top.opener) {
       origin = this.config.origin || '*';

--- a/src/child.js
+++ b/src/child.js
@@ -20,6 +20,12 @@ class Child {
     if (typeof config.shouldInitImmediately === 'undefined') {
       config.shouldInitImmediately = true;
     }
+    if (typeof config.parse === 'undefined') {
+      config.parse = JSON.parse;
+    }
+    if (typeof config.stringify === 'undefined') {
+      config.stringify = JSON.stringify;
+    }
 
     this.tabName = window.name;
     this.tabId = null;
@@ -31,7 +37,7 @@ class Child {
     if (this.shouldInitImmediately) {
       this.init();
     }
-  };
+  }
 
   /**
    * Check is sessionStorage is present on window
@@ -42,7 +48,7 @@ class Child {
       return true;
     }
     return false;
-  };
+  }
 
   /**
    * Get stored data from sessionStorage
@@ -54,7 +60,7 @@ class Child {
     }
 
     return window.sessionStorage.getItem(this.sessionStorageKey);
-  };
+  }
 
   /**
    * Set stored data from sessionStorage
@@ -67,7 +73,7 @@ class Child {
 
     window.sessionStorage.setItem(this.sessionStorageKey, dataReceived);
     return dataReceived;
-  };
+  }
 
   /**
    * Get stored data from sessionStorage and parse it
@@ -83,7 +89,7 @@ class Child {
 
       this._parseData(storedData);
     }
-  };
+  }
 
   /**
    * Parse data fetched from sessionStorage
@@ -94,14 +100,14 @@ class Child {
 
     // Expecting JSON data
     try {
-      actualData = JSON.parse(dataReceived);
+      actualData = this.config.parse(dataReceived);
       this.tabId = actualData && actualData.id;
       this.tabName = actualData && actualData.name;
       this.tabParentName = actualData && actualData.parentName;
     } catch (e) {
       throw new Error(WarningTextEnum.INVALID_DATA);
-    };
-  };
+    }
+  }
 
   /**
    * The core of this file
@@ -142,7 +148,7 @@ class Child {
     /**
      * When Parent sends an Acknowledgement to the Child's request of setting up a communication channel
      * along with the tab's identity i.e. id, name and it's parent(itself) to the child tab.
-    */
+     */
     if (data.indexOf(PostMessageEventNamesEnum.HANDSHAKE_WITH_PARENT) > -1) {
       let msg;
 
@@ -168,7 +174,7 @@ class Child {
       dataReceived = data.split(PostMessageEventNamesEnum.PARENT_COMMUNICATED)[1];
 
       try {
-        dataReceived = JSON.parse(dataReceived);
+        dataReceived = this.config.parse(dataReceived);
       } catch (e) {
         throw new Error(WarningTextEnum.INVALID_JSON);
       }
@@ -177,13 +183,13 @@ class Child {
         this.config.onParentCommunication(dataReceived);
       }
     }
-  };
+  }
 
   /**
    * Attach postmessage and onbeforeunload event listeners
    */
   addListeners() {
-    window.onbeforeunload = (evt) => {
+    window.onbeforeunload = evt => {
       let msg = {
         id: this.tabId,
         isSiteInsideFrame: this.config.isSiteInsideFrame
@@ -194,7 +200,7 @@ class Child {
 
     window.removeEventListener('message', evt => this.onCommunication(evt));
     window.addEventListener('message', evt => this.onCommunication(evt));
-  };
+  }
 
   /**
    * Call a user-defined method `onHandShakeExpiry`
@@ -220,13 +226,13 @@ class Child {
 
     let type = _prefixType || PostMessageEventNamesEnum.CUSTOM;
 
-    msg = type + JSON.stringify(msg);
+    msg = type + this.config.stringify(msg);
 
     if (window.top.opener) {
       origin = this.config.origin || '*';
       window.top.opener.postMessage(msg, origin);
     }
-  };
+  }
 
   /**
    * Get current Tab info i.e. id, name and parentName
@@ -239,7 +245,7 @@ class Child {
       parentName: this.tabParentName,
       isSiteInsideFrame: this.config.isSiteInsideFrame
     };
-  };
+  }
   /**
    * API ends here ->
    */
@@ -258,6 +264,6 @@ class Child {
       this.config.onReady();
     }
   }
-};
+}
 
 export default Child;

--- a/src/child.js
+++ b/src/child.js
@@ -100,7 +100,7 @@ class Child {
 
     // Expecting JSON data
     try {
-      actualData = this.config.parse(dataReceived);
+      actualData = this.parse(dataReceived);
       this.tabId = actualData && actualData.id;
       this.tabName = actualData && actualData.name;
       this.tabParentName = actualData && actualData.parentName;
@@ -174,7 +174,7 @@ class Child {
       dataReceived = data.split(PostMessageEventNamesEnum.PARENT_COMMUNICATED)[1];
 
       try {
-        dataReceived = this.config.parse(dataReceived);
+        dataReceived = this.parse(dataReceived);
       } catch (e) {
         throw new Error(WarningTextEnum.INVALID_JSON);
       }
@@ -226,7 +226,7 @@ class Child {
 
     let type = _prefixType || PostMessageEventNamesEnum.CUSTOM;
 
-    msg = type + this.config.stringify(msg);
+    msg = type + this.stringify(msg);
 
     if (window.top.opener) {
       origin = this.config.origin || '*';

--- a/src/event-listeners/postmessage.js
+++ b/src/event-listeners/postmessage.js
@@ -32,7 +32,7 @@ let PostMessageListener = {};
 /**
  * OnLoad Event - it serves as an communication establishment source from Child tab
  */
-PostMessageListener._onLoad = (data) => {
+PostMessageListener._onLoad = data => {
   let tabs,
     dataToSend,
     tabInfo = data.split(PostMessageEventNamesEnum.LOADED)[1];
@@ -41,7 +41,7 @@ PostMessageListener._onLoad = (data) => {
   // last opened tab will get refreshed(browser behavior). WOW! Handle this now.
   if (tabInfo) {
     try {
-      tabInfo = JSON.parse(tabInfo);
+      tabInfo = tabUtils.config.parse(tabInfo);
       // If Child knows its UUID, means Parent was refreshed and Child did not
       if (tabInfo.id) {
         tabs = tabUtils.getAll();
@@ -59,7 +59,7 @@ PostMessageListener._onLoad = (data) => {
   if (window.newlyTabOpened) {
     try {
       dataToSend = PostMessageEventNamesEnum.HANDSHAKE_WITH_PARENT;
-      dataToSend += JSON.stringify({
+      dataToSend += tabUtils.config.stringify({
         id: window.newlyTabOpened.id,
         name: window.newlyTabOpened.name,
         parentName: window.name
@@ -83,7 +83,7 @@ PostMessageListener._onCustomMessage = (data, type) => {
     tabInfo = data.split(type)[1];
 
   try {
-    tabInfo = JSON.parse(tabInfo);
+    tabInfo = tabUtils.config.parse(tabInfo);
   } catch (e) {
     throw new Error(WarningTextEnum.INVALID_JSON);
   }
@@ -93,7 +93,7 @@ PostMessageListener._onCustomMessage = (data, type) => {
     type
   };
 
-  event = new CustomEvent('onCustomChildMessage', {'detail': eventData});
+  event = new CustomEvent('onCustomChildMessage', { detail: eventData });
 
   window.dispatchEvent(event);
   // window.newlyTabOpened = null;
@@ -107,22 +107,24 @@ PostMessageListener._onCustomMessage = (data, type) => {
  *
  * @param  {Object} data
  */
-PostMessageListener._onBeforeUnload = (data) => {
-  let tabs, tabInfo = data.split(PostMessageEventNamesEnum.ON_BEFORE_UNLOAD)[1];
+PostMessageListener._onBeforeUnload = data => {
+  let tabs,
+    tabInfo = data.split(PostMessageEventNamesEnum.ON_BEFORE_UNLOAD)[1];
 
   try {
-    tabInfo = JSON.parse(tabInfo);
+    tabInfo = tabUtils.config.parse(tabInfo);
   } catch (e) {
     throw new Error(WarningTextEnum.INVALID_JSON);
   }
 
   if (tabUtils.tabs.length) {
     tabs = tabUtils.getAll();
-    window.newlyTabOpened = arrayUtils.searchByKeyName(tabs, 'id', tabInfo.id) || window.newlyTabOpened;
+    window.newlyTabOpened =
+      arrayUtils.searchByKeyName(tabs, 'id', tabInfo.id) || window.newlyTabOpened;
   }
 
   // CustomEvent is not supported in IE, but polyfill will take care of it
-  let event = new CustomEvent('onChildUnload', {'detail': tabInfo});
+  let event = new CustomEvent('onChildUnload', { detail: tabInfo });
 
   window.dispatchEvent(event);
 };
@@ -131,7 +133,7 @@ PostMessageListener._onBeforeUnload = (data) => {
  * onNewTab - It's the entry point for data processing after receiving any postmessage form any Child Tab
  * @param  {Object} message
  */
-PostMessageListener.onNewTab = (message) => {
+PostMessageListener.onNewTab = message => {
   let data = message.data;
 
   /**

--- a/src/parent.js
+++ b/src/parent.js
@@ -26,10 +26,10 @@ class Parent {
     if (typeof config.shouldInitImmediately === 'undefined') {
       config.shouldInitImmediately = true;
     }
-    if (typeof config.parse === 'undefined') {
+    if (typeof config.parse !== 'function') {
       config.parse = JSON.parse;
     }
-    if (typeof config.stringify === 'undefined') {
+    if (typeof config.stringify !== 'function') {
       config.stringify = JSON.stringify;
     }
 

--- a/src/parent.js
+++ b/src/parent.js
@@ -33,12 +33,20 @@ class Parent {
     this.Tab = Tab;
     Object.assign(this, config);
 
+    if (!config.parse) {
+      config.parse = JSON.parse;
+    }
+
+    if (!config.stringify) {
+      config.stringify = JSON.stringify;
+    }
+
     tabUtils.config = config;
 
     if (this.shouldInitImmediately) {
       this.init();
     }
-  };
+  }
 
   addInterval() {
     let i,
@@ -59,7 +67,7 @@ class Parent {
       /**
        * The check is required since tab would be removed when closed(in case of `removeClosedTabs` flag),
        * irrespective of heatbeat controller
-      */
+       */
       if (tabs[i] && tabs[i].ref) {
         tabs[i].status = tabs[i].ref.closed ? TabStatusEnum.CLOSE : TabStatusEnum.OPEN;
       }
@@ -69,7 +77,7 @@ class Parent {
     if (this.onPollingCallback) {
       this.onPollingCallback();
     }
-  };
+  }
 
   /**
    * Poll all tabs for their status - OPENED / CLOSED
@@ -79,19 +87,23 @@ class Parent {
    */
   startPollingTabs() {
     heartBeat = window.setInterval(() => this.addInterval(), this.heartBeatInterval);
-  };
+  }
 
   /**
    * Compare tab status - OPEN vs CLOSE
    * @param  {Object} tab
    */
   watchStatus(tab) {
-    if (!tab || !tab.ref) { return false; }
+    if (!tab || !tab.ref) {
+      return false;
+    }
     let newStatus = tab.ref.closed ? TabStatusEnum.CLOSE : TabStatusEnum.OPEN,
       oldStatus = tab.status;
 
     // If last and current status(inside a polling interval) are same, don't do anything
-    if (!newStatus || newStatus === oldStatus) { return false; }
+    if (!newStatus || newStatus === oldStatus) {
+      return false;
+    }
 
     // OPEN to CLOSE state
     if (oldStatus === TabStatusEnum.OPEN && newStatus === TabStatusEnum.CLOSE) {
@@ -99,7 +111,7 @@ class Parent {
       tabUtils._remove(tab);
     }
     // Change from CLOSE to OPEN state is never gonna happen ;)
-  };
+  }
 
   /**
    * Called when a child is refreshed/closed
@@ -119,12 +131,20 @@ class Parent {
   customEventUnListener(ev) {
     this.enableElements();
 
-    if (ev.detail && ev.detail.type === PostMessageEventNamesEnum.HANDSHAKE && this.onHandshakeCallback) {
+    if (
+      ev.detail &&
+      ev.detail.type === PostMessageEventNamesEnum.HANDSHAKE &&
+      this.onHandshakeCallback
+    ) {
       this.onHandshakeCallback(ev.detail.tabInfo);
-    } else if (ev.detail && ev.detail.type === PostMessageEventNamesEnum.CUSTOM && this.onChildCommunication) {
+    } else if (
+      ev.detail &&
+      ev.detail.type === PostMessageEventNamesEnum.CUSTOM &&
+      this.onChildCommunication
+    ) {
       this.onChildCommunication(ev.detail.tabInfo);
     }
-  };
+  }
 
   /**
    * Attach postmessage, native and custom listeners to the window
@@ -143,7 +163,7 @@ class Parent {
     window.onbeforeunload = () => {
       tabUtils.broadCastAll(PostMessageEventNamesEnum.PARENT_DISCONNECTED);
     };
-  };
+  }
 
   /**
    * API methods exposed for Public
@@ -152,7 +172,7 @@ class Parent {
    */
   enableElements() {
     domUtils.enable('data-tab-opener');
-  };
+  }
 
   /**
    * Return list of all tabs
@@ -160,7 +180,7 @@ class Parent {
    */
   getAllTabs() {
     return tabUtils.getAll();
-  };
+  }
 
   /**
    * Return list of all OPENED tabs
@@ -168,7 +188,7 @@ class Parent {
    */
   getOpenedTabs() {
     return tabUtils.getOpened();
-  };
+  }
 
   /**
    * Return list of all CLOSED tabs
@@ -184,7 +204,7 @@ class Parent {
    */
   closeAllTabs() {
     return tabUtils.closeAll();
-  };
+  }
 
   /**
    * Close a specific tab
@@ -192,7 +212,7 @@ class Parent {
    */
   closeTab(id) {
     return tabUtils.closeTab(id);
-  };
+  }
 
   /**
    * Send a postmessage to all OPENED tabs
@@ -234,7 +254,7 @@ class Parent {
     }
 
     return tab;
-  };
+  }
 
   /**
    * API methods exposed for Public ends here
@@ -245,7 +265,7 @@ class Parent {
    */
   init() {
     this.addEventListeners();
-  };
-};
+  }
+}
 
 export default Parent;

--- a/src/parent.js
+++ b/src/parent.js
@@ -26,20 +26,18 @@ class Parent {
     if (typeof config.shouldInitImmediately === 'undefined') {
       config.shouldInitImmediately = true;
     }
+    if (typeof config.parse === 'undefined') {
+      config.parse = JSON.parse;
+    }
+    if (typeof config.stringify === 'undefined') {
+      config.stringify = JSON.stringify;
+    }
 
     // reset tabs with every new Object
     tabUtils.tabs = [];
 
     this.Tab = Tab;
     Object.assign(this, config);
-
-    if (!config.parse) {
-      config.parse = JSON.parse;
-    }
-
-    if (!config.stringify) {
-      config.stringify = JSON.stringify;
-    }
 
     tabUtils.config = config;
 

--- a/src/utils/tab.js
+++ b/src/utils/tab.js
@@ -9,7 +9,10 @@ import WarningTextEnum from '../enums/WarningTextEnum';
 
 let tabUtils = {
   tabs: [],
-  config: {}
+  config: {
+    parse: JSON.parse,
+    stringify: JSON.stringify
+  }
 };
 
 /**
@@ -18,7 +21,7 @@ let tabUtils = {
  * This can be done explictly by passing `removeClosedTabs` key while instantiating Parent.
  * @param  {Object} tab
  */
-tabUtils._remove = (tab) => {
+tabUtils._remove = tab => {
   let index;
 
   index = arrayUtils.searchByKeyName(tabUtils.tabs, 'id', tab.id, 'index');
@@ -31,10 +34,10 @@ tabUtils._remove = (tab) => {
  * @param  {String} msg
  * @return {String} modified msg
  */
-tabUtils._preProcessMessage = (msg) => {
+tabUtils._preProcessMessage = msg => {
   // make msg always an object to support JSON support
   try {
-    msg = JSON.stringify(msg);
+    msg = tabUtils.config.stringify(msg);
   } catch (e) {
     throw new Error(WarningTextEnum.INVALID_JSON);
   }
@@ -50,7 +53,7 @@ tabUtils._preProcessMessage = (msg) => {
  * @param  {Object} tab
  * @return {Object} - this
  */
-tabUtils.addNew = (tab) => {
+tabUtils.addNew = tab => {
   tabUtils.tabs.push(tab);
   return this;
 };
@@ -82,7 +85,7 @@ tabUtils.getAll = () => {
  * @param  {String} id
  * @return {Object} this
  */
-tabUtils.closeTab = (id) => {
+tabUtils.closeTab = id => {
   let tab = arrayUtils.searchByKeyName(tabUtils.tabs, 'id', id);
 
   if (tab && tab.ref) {
@@ -115,7 +118,8 @@ tabUtils.closeAll = () => {
  * @param  {Boolean} isSiteInsideFrame
  */
 tabUtils.broadCastAll = (msg, isSiteInsideFrame) => {
-  let i, tabs = tabUtils.getOpened();
+  let i,
+    tabs = tabUtils.getOpened();
 
   msg = tabUtils._preProcessMessage(msg);
 

--- a/src/utils/tab.js
+++ b/src/utils/tab.js
@@ -9,10 +9,7 @@ import WarningTextEnum from '../enums/WarningTextEnum';
 
 let tabUtils = {
   tabs: [],
-  config: {
-    parse: JSON.parse,
-    stringify: JSON.stringify
-  }
+  config: {}
 };
 
 /**

--- a/tests/child.spec.js
+++ b/tests/child.spec.js
@@ -90,7 +90,10 @@ describe('Child', () => {
 		});
 		it('should parse stringified data', () => {
 			spyOn(JSON, 'parse');
-			child._parseData(JSON.stringify({a: 1}));
+			
+			const _child = new Child();
+			
+			_child._parseData(JSON.stringify({a: 1}));
 			expect(JSON.parse).toHaveBeenCalled();
 		});
 	});
@@ -147,11 +150,12 @@ describe('Child', () => {
 			expect(child.config.onInitialize).toHaveBeenCalled();
 		});
 		it('should call user-defined method when PARENT_COMMUNICATED event', () => {
+			spyOn(JSON, 'parse');
+			
 			let child = new Child({
 				onParentCommunication: function () {}
 			});
 
-			spyOn(JSON, 'parse');
 			spyOn(child.config, 'onParentCommunication');
 
 			child.onCommunication({

--- a/tests/child.spec.js
+++ b/tests/child.spec.js
@@ -96,6 +96,20 @@ describe('Child', () => {
 			_child._parseData(JSON.stringify({a: 1}));
 			expect(JSON.parse).toHaveBeenCalled();
 		});
+		it('should parse stringified data with a custom parser', () => {
+			const custom = {
+				parse: (msg) => JSON.parse(msg, () => '')
+			};
+			
+			spyOn(custom, 'parse');
+			
+			const _child = new Child({
+				parse: custom.parse
+			});
+			
+			_child._parseData(JSON.stringify({a: 1}));
+			expect(custom.parse).toHaveBeenCalled();
+		});
 	});
 	describe('method: onCommunication', () => {
 		it('should clear timeout on getting message from parent', () => {
@@ -163,6 +177,27 @@ describe('Child', () => {
 			});
 
 			expect(JSON.parse).toHaveBeenCalled();
+			expect(child.config.onParentCommunication).toHaveBeenCalled();
+		});
+		it('should call user-defined method when PARENT_COMMUNICATED event with a custom parser', () => {
+			const custom = {
+				parse: (msg) => JSON.parse(msg, () => '')
+			};
+			
+			spyOn(custom, 'parse');
+			
+			let child = new Child({
+				onParentCommunication: function () {},
+				parse: custom.parse
+			});
+
+			spyOn(child.config, 'onParentCommunication');
+
+			child.onCommunication({
+				data: PostMessageEventNamesEnum.PARENT_COMMUNICATED + JSON.stringify({a: 1})
+			});
+
+			expect(custom.parse).toHaveBeenCalled();
 			expect(child.config.onParentCommunication).toHaveBeenCalled();
 		});
 	});

--- a/tests/event-listeners/postmessage.spec.js
+++ b/tests/event-listeners/postmessage.spec.js
@@ -7,7 +7,10 @@ import PostMessageListener from '../../src/event-listeners/postmessage';
 
 function beforeEveryEach() {
 	tabUtils.tabs = [];
-	tabUtils.config = {};
+	tabUtils.config = {
+		parse: JSON.parse,
+		stringify: JSON.stringify
+	};
 	setNewTabInfo();
 }
 function afterEveryEach() { // teardown

--- a/tests/utils/tab.spec.js
+++ b/tests/utils/tab.spec.js
@@ -26,6 +26,10 @@ function addTabs() {
 describe('tabUtils', () => {
 	beforeEach(() => {
 		tabUtils.tabs = [];
+		tabUtils.config = {
+			parse: JSON.parse,
+			stringify: JSON.stringify
+		};
 	});
 	afterEach(() => {
 		tab1 = null;
@@ -66,6 +70,9 @@ describe('tabUtils', () => {
 	describe('method: _preProcessMessage', () => {
 		it('should stringify msg sent', () => {
 			spyOn(JSON, 'stringify');
+			
+			tabUtils.config.stringify = JSON.stringify;
+			
 			let msg = 'Some message';
 
 			tabUtils._preProcessMessage(msg);

--- a/tests/utils/tab.spec.js
+++ b/tests/utils/tab.spec.js
@@ -26,10 +26,7 @@ function addTabs() {
 describe('tabUtils', () => {
 	beforeEach(() => {
 		tabUtils.tabs = [];
-		tabUtils.config = {
-			parse: JSON.parse,
-			stringify: JSON.stringify
-		};
+		tabUtils.config = {	};
 	});
 	afterEach(() => {
 		tab1 = null;
@@ -95,9 +92,11 @@ describe('tabUtils', () => {
 		});
 
 		it('should prepend if message is of a particular type', () => {
+			tabUtils.config.stringify = JSON.stringify;
+			
 			let msg = 'Some message';
+			
 			let value = tabUtils._preProcessMessage(msg);
-
 			expect(value.indexOf(PostMessageEventNamesEnum.PARENT_COMMUNICATED)).not.toBe(-1);
 		});
 	});
@@ -206,6 +205,8 @@ describe('tabUtils', () => {
 	});
 	describe('method: broadCastAll', () => {
 		it('should broadcast a message to all the opened tabs', () => {
+			tabUtils.config.stringify = JSON.stringify;
+			
 			let result;
 
 			addTabs();
@@ -227,6 +228,8 @@ describe('tabUtils', () => {
 	});
 	describe('method: broadCastTo', () => {
 		it('should broadcast a message to the specified tab', () => {
+			tabUtils.config.stringify = JSON.stringify;
+			
 			let result;
 
 			addTabs();

--- a/tests/utils/tab.spec.js
+++ b/tests/utils/tab.spec.js
@@ -78,6 +78,21 @@ describe('tabUtils', () => {
 			tabUtils._preProcessMessage(msg);
 			expect(JSON.stringify).toHaveBeenCalledWith(msg);
 		});
+		
+		it('should stringify msg sent with custom stringifier', () => {
+			const custom = {
+				stringify: (msg) => typeof msg === 'string' ? msg : `${msg}`
+			};
+			
+			spyOn(custom, 'stringify');
+			
+			tabUtils.config.stringify = custom.stringify;
+			
+			let msg = 'Some message';
+
+			tabUtils._preProcessMessage(msg);
+			expect(custom.stringify).toHaveBeenCalledWith(msg);
+		});
 
 		it('should prepend if message is of a particular type', () => {
 			let msg = 'Some message';


### PR DESCRIPTION
Modify the use of `config` in both `Child` and `Parent` classes, as well as `tabUtils`, to allow for custom stringifiers / parsers of the messages passed. When not provided, they default to `JSON.parse` and `JSON.stringify`.

Should resolve #16 