### PR TITLE
Improve tab event sourcing

### DIFF
--- a/src/event-listeners/postmessage.js
+++ b/src/event-listeners/postmessage.js
@@ -46,9 +46,11 @@ PostMessageListener._onLoad = data => {
       if (tabInfo.id) {
         tabs = tabUtils.getAll();
         if (tabs.length) {
-          window.newlyTabOpened = tabs[tabs.length - 1];
-          window.newlyTabOpened.id = tabInfo.id;
-          window.newlyTabOpened.name = tabInfo.name || tabInfo.windowName;
+          // Find the specific tab that sent the LOADED message by its ID
+          window.newlyTabOpened = arrayUtils.searchByKeyName(tabs, 'id', tabInfo.id);
+          if (window.newlyTabOpened) {
+            window.newlyTabOpened.name = tabInfo.name || tabInfo.windowName;
+          }
         }
       }
     } catch (e) {

--- a/src/tab.js
+++ b/src/tab.js
@@ -26,12 +26,6 @@ class Tab {
 
     domUtils.disable('data-tab-opener');
 
-    window.newlyTabOpened = {
-      id: this.id,
-      name: this.name || this.windowName,
-      ref: this.ref
-    };
-
     // Push it to the list of tabs
     tabUtils.addNew(this);
 


### PR DESCRIPTION
This PR depends on #69 being accepted

- feat(tab): use source window as ref to send handshake instead of setting a window var

Fixes: #15